### PR TITLE
 - Serilog.Sinks.Slack.proj: Updated Serilog to latest, included need…

### DIFF
--- a/src/Serilog.Sinks.Slack.Test/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Slack.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Serilog.Sinks.Slack.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Serilog.Sinks.Slack.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e346abec-cd1f-4630-9863-0562586da590")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Serilog.Sinks.Slack.Test/Serilog.Sinks.Slack.Test.csproj
+++ b/src/Serilog.Sinks.Slack.Test/Serilog.Sinks.Slack.Test.csproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E346ABEC-CD1F-4630-9863-0562586DA590}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Serilog.Sinks.Slack.Test</RootNamespace>
+    <AssemblyName>Serilog.Sinks.Slack.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.2.1\lib\net46\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="SlackSinkTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Serilog.Sinks.Slack\Serilog.Sinks.Slack.csproj">
+      <Project>{a75fa4dc-27af-46ea-bb5b-8f1abbf33645}</Project>
+      <Name>Serilog.Sinks.Slack</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Serilog.Sinks.Slack.Test/SlackSinkTests.cs
+++ b/src/Serilog.Sinks.Slack.Test/SlackSinkTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Serilog.Sinks.Slack.Test
+{
+    [TestClass]
+    public class SlackSinkTests
+    {
+        [TestMethod]
+        public void SendMessageTests()
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Slack("xxxxxx", "#xxx", "I ghost", ":ghost:")
+                .CreateLogger();
+
+            Log.Logger.Verbose("1 Verbose");
+            Log.Logger.Debug("2 Debug");
+            Log.Logger.Error("3 Error");
+
+            try
+            {
+                throw new Exception("some logged exception!");
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Fatal(ex, "4 Fatal");
+            }
+
+            Log.Logger.Information("5 Information");
+            Log.Logger.Warning("6 Warning");
+            Log.Logger.Debug("7 Formatting {myProp}", new { myProp = "test" });
+
+            Thread.Sleep(5000);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Slack.Test/packages.config
+++ b/src/Serilog.Sinks.Slack.Test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Serilog" version="2.2.1" targetFramework="net46" />
+</packages>

--- a/src/Serilog.Sinks.Slack.sln
+++ b/src/Serilog.Sinks.Slack.sln
@@ -1,11 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Slack", "Serilog.Sinks.Slack\Serilog.Sinks.Slack.csproj", "{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Slack.Sample", "Serilog.Sinks.Slack.Sample\Serilog.Sinks.Slack.Sample.csproj", "{74549E6B-1B47-4AF7-8A6C-B99582120781}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Slack.Test", "Serilog.Sinks.Slack.Test\Serilog.Sinks.Slack.Test.csproj", "{E346ABEC-CD1F-4630-9863-0562586DA590}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}.Release|Any CPU.Build.0 = Release|Any CPU
-		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E346ABEC-CD1F-4630-9863-0562586DA590}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E346ABEC-CD1F-4630-9863-0562586DA590}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E346ABEC-CD1F-4630-9863-0562586DA590}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E346ABEC-CD1F-4630-9863-0562586DA590}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.Slack/SeqLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Slack/SeqLoggerConfigurationExtensions.cs
@@ -2,21 +2,46 @@
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
-using Serilog.Sinks.Slack;
 
-namespace Serilog
+namespace Serilog.Sinks.Slack
 {
+    /// <summary>
+    /// Provides extension methods on <see cref="LoggerSinkConfiguration"/>.
+    /// </summary>
     public static class SeqLoggerConfigurationExtensions
     {
+        /// <summary>
+        /// <see cref="LoggerSinkConfiguration"/> extension that provides configuration chaining.
+        /// <example>
+        ///     new LoggerConfiguration()
+        ///         .MinimumLevel.Verbose()
+        ///         .WriteTo.Slack("webHookUrl", "channel" ,"username", "icon")
+        ///         .CreateLogger();
+        /// </example>
+        /// </summary>
+        /// <param name="loggerSinkConfiguration">Instance of <see cref="LoggerSinkConfiguration"/> object.</param>
+        /// <param name="webhookUrl">Slack team post URI.</param>
+        /// <param name="customChannel">Name of Slack channel to which message should be posted.</param>
+        /// <param name="customUsername">User name that will be displayed as a name of the message sender.</param>
+        /// <param name="customIcon">Icon that will be used as a sender avatar.</param>
+        /// <param name="restrictedToMinimumLevel"><see cref="LogEventLevel"/> value that specifies minimum logging level that will be allowed to be logged.</param>
+        /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Slack(
             this LoggerSinkConfiguration loggerSinkConfiguration,
-            string webhookUrl, string customChannel = null, string customUsername = null, string customIcon = null,
+            string webhookUrl,
+            string customChannel = null,
+            string customUsername = null,
+            string customIcon = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
-            if (loggerSinkConfiguration == null) throw new ArgumentNullException(nameof(loggerSinkConfiguration));
-            if (string.IsNullOrWhiteSpace(webhookUrl)) throw new ArgumentNullException(nameof(webhookUrl));
+            if (loggerSinkConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerSinkConfiguration));
+
+            if (string.IsNullOrWhiteSpace(webhookUrl))
+                throw new ArgumentNullException(nameof(webhookUrl));
 
             ILogEventSink sink = new SlackSink(webhookUrl, customChannel, customUsername, customIcon);
+
             return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/src/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -31,26 +31,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.2.3\lib\net452\RestSharp.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.2.1\lib\net46\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.0.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Serilog.Sinks.Slack/SlackSink.cs
+++ b/src/Serilog.Sinks.Slack/SlackSink.cs
@@ -1,23 +1,58 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic;
-using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
-using RestSharp;
+using Newtonsoft.Json;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Slack
 {
+    /// <summary>
+    /// Implements <see cref="PeriodicBatchingSink"/> and provides means needed for sending Serilog log events to Slack.
+    /// </summary>
     public class SlackSink : PeriodicBatchingSink
     {
+        #region Fields
+
+        private static readonly HttpClient Client = new HttpClient();
+
+        private static readonly Dictionary<LogEventLevel, string> Colors = new Dictionary<LogEventLevel, string>
+        {
+            {LogEventLevel.Verbose, "#777"},
+            {LogEventLevel.Debug, "#777"},
+            {LogEventLevel.Information, "#5bc0de"},
+            {LogEventLevel.Warning, "#f0ad4e"},
+            {LogEventLevel.Error, "#d9534f"},
+            {LogEventLevel.Fatal, "#d9534f"}
+        };
+
         private readonly string _webhookUrl;
+
         private readonly string _customChannel;
+
         private readonly string _customUserName;
+
         private readonly string _customIcon;
 
-        public SlackSink(string webhookUrl, string customChannel = null, string customUserName = null, string customIcon = null) : base(50, TimeSpan.FromSeconds(5))
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Initializes new instance of <see cref="SlackSink"/>.
+        /// </summary>
+        /// <param name="webhookUrl">Slack team post URI.</param>
+        /// <param name="customChannel">Name of Slack channel to which message should be posted.</param>
+        /// <param name="customUserName">User name that will be displayed as a name of the message sender.</param>
+        /// <param name="customIcon">Icon that will be used as a sender avatar.</param>
+        public SlackSink(
+            string webhookUrl,
+            string customChannel = null,
+            string customUserName = null,
+            string customIcon = null)
+            : base(50, TimeSpan.FromSeconds(5))
         {
             _webhookUrl = webhookUrl;
             _customChannel = customChannel;
@@ -25,86 +60,71 @@ namespace Serilog.Sinks.Slack
             _customIcon = customIcon;
         }
 
+        #endregion
+
+        /// <summary>
+        /// Overrides <see cref="PeriodicBatchingSink.EmitBatchAsync"/> method and uses <see cref="HttpClient"/> to post <see cref="LogEvent"/> to Slack.
+        /// /// </summary>
+        /// <param name="events">Collection of <see cref="LogEvent"/>.</param>
+        /// <returns>Awaitable task.</returns>
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             foreach (var logEvent in events)
             {
-                var client = new RestClient(_webhookUrl);
-                var request = new RestRequest(Method.POST);
+                var message = CreateMessage(logEvent, _customChannel, _customUserName, _customIcon);
 
-                dynamic body = new ExpandoObject();
-                body.text = logEvent.RenderMessage();
-                body.attachments = WrapInAttachment(logEvent).ToArray();
+                var json = JsonConvert.SerializeObject(message, Newtonsoft.Json.Formatting.Indented);
 
-
-                if (!string.IsNullOrWhiteSpace(_customChannel))
-                    body.channel = _customChannel;
-                if (!string.IsNullOrWhiteSpace(_customUserName))
-                    body.username = _customUserName;
-                if (!string.IsNullOrWhiteSpace(_customIcon))
-                    body.icon_emoji = _customIcon;
-
-                request.AddJsonBody(body);
-                await client.ExecuteTaskAsync(request);
+                await Client.PostAsync(_webhookUrl, new StringContent(json));
             }
         }
 
-        private IEnumerable<dynamic> WrapInAttachment(LogEvent log)
+        private static dynamic CreateMessage(LogEvent logEvent, string channel, string username, string emoji)
         {
-            var result = new List<dynamic>();
-            result.Add(new
-            {
-                fallback = $"[{log.Level}]{log.RenderMessage()}",
-                color = GetAttachmentColor(log.Level),
-                fields = new[]
-                {
-                    CreateAttachmentField("Level", log.Level.ToString()),
-                    CreateAttachmentField("Timestamp", log.Timestamp.ToString())
-                }
-            });
+            dynamic message = new ExpandoObject();
+            message.text = logEvent.RenderMessage();
+            message.channel = string.IsNullOrWhiteSpace(channel) ? string.Empty : channel;
+            message.username = string.IsNullOrWhiteSpace(username) ? string.Empty : username;
+            message.icon_emoji = string.IsNullOrWhiteSpace(emoji) ? string.Empty : emoji;
+            message.attachments = CreateAttachments(logEvent);
 
-            if (log.Exception != null)
-                result.Add(WrapInAttachment(log.Exception));
-
-            return result;
+            return message;
         }
 
-        private object WrapInAttachment(Exception ex)
+        private static List<dynamic> CreateAttachments(LogEvent logEvent)
         {
-            return new
+            var attachments = new List<dynamic>
+            {
+                new
+                {
+                    fallback = $"[{logEvent.Level}]{logEvent.RenderMessage()}",
+                    color = Colors[logEvent.Level],
+                    fields = new List<dynamic>
+                    {
+                        new {title = "Level", value = logEvent.Level.ToString()},
+                        new {title = "Timestamp", value = logEvent.Timestamp.ToString()}
+                    }
+                }
+            };
+
+            if (logEvent.Exception == null)
+                return attachments;
+
+            attachments.Add(new
             {
                 title = "Exception",
-                fallback = $"Exception: {ex.Message} \n {ex.StackTrace}",
-                color = GetAttachmentColor(LogEventLevel.Fatal),
-                fields = new[]
+                fallback = $"Exception: {logEvent.Exception.Message} \n {logEvent.Exception.StackTrace}",
+                color = Colors[LogEventLevel.Fatal],
+                fields = new List<dynamic>
                 {
-                    CreateAttachmentField("Message", ex.Message),
-                    CreateAttachmentField("Type", "`"+ex.GetType().Name+"`"),
-                    CreateAttachmentField("Stack Trace", "```"+ex.StackTrace+"```", false)
+                    new {title = "Message", value = logEvent.Exception.Message},
+                    new {title = "Type", value = "`" + logEvent.Exception.GetType().Name + "`"},
+                    new {title = "Stack Trace", value = "```" + logEvent.Exception.StackTrace + "```", @short = false}
                 },
-                mrkdwn_in = new[] { "fields" }
-            };
-        }
+                mrkdwn_in = new List<string> { "fields" }
+            });
 
-        private object CreateAttachmentField(string title, string value, bool @short = true)
-        {
-            return new { title, value, @short };
-        }
-
-        private string GetAttachmentColor(LogEventLevel level)
-        {
-            switch (level)
-            {
-                case LogEventLevel.Information:
-                    return "#5bc0de";
-                case LogEventLevel.Warning:
-                    return "#f0ad4e";
-                case LogEventLevel.Error:
-                case LogEventLevel.Fatal:
-                    return "#d9534f";
-                default:
-                    return "#777";
-            }
+            return attachments;
         }
     }
 }

--- a/src/Serilog.Sinks.Slack/packages.config
+++ b/src/Serilog.Sinks.Slack/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.2.3" targetFramework="net452" requireReinstallation="true" />
-  <package id="Serilog" version="1.5.14" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
+  <package id="Serilog" version="2.2.1" targetFramework="net46" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
The current version is not working with latest Serilog, I think because PeriodicBatchingSink is now in different library: Serilog.Sinks.PeriodicBatching, so I updated the references.

Also I removed RestSharp dependency and used HttpClient which required Newtonsoft.Json, which made the number of dependencies the same regarding external stuff, but Newtonsoft.Json is much more common one, and in my case RestSharp was something that was used only here.

I did some small refactoring also.

I hope this makes sense to you, if not thank you for the sink anyway :)