### PR TITLE
Downgraded to .NET 4.5

### DIFF
--- a/src/Serilog.Sinks.Slack.Sample/App.config
+++ b/src/Serilog.Sinks.Slack.Sample/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
     </startup>
 </configuration>

--- a/src/Serilog.Sinks.Slack.Sample/Program.cs
+++ b/src/Serilog.Sinks.Slack.Sample/Program.cs
@@ -25,6 +25,8 @@ namespace Serilog.Sinks.Slack.Sample
             Log.Logger.Information("5 Information");
             Log.Logger.Warning("6 Warning");
             Log.Logger.Debug("7 Formatting {myProp}", new { myProp = "test" });
+
+            Console.Read();
         }
     }
 }

--- a/src/Serilog.Sinks.Slack.Sample/Serilog.Sinks.Slack.Sample.csproj
+++ b/src/Serilog.Sinks.Slack.Sample/Serilog.Sinks.Slack.Sample.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Sinks.Slack.Sample</RootNamespace>
     <AssemblyName>Serilog.Sinks.Slack.Sample</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -34,12 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Serilog.Sinks.Slack.Sample/packages.config
+++ b/src/Serilog.Sinks.Slack.Sample/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.5.14" targetFramework="net452" />
+  <package id="Serilog" version="2.3.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.Slack.sln
+++ b/src/Serilog.Sinks.Slack.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Slack", "Serilog.Sinks.Slack\Serilog.Sinks.Slack.csproj", "{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Slack.Sample", "Serilog.Sinks.Slack.Sample\Serilog.Sinks.Slack.Sample.csproj", "{74549E6B-1B47-4AF7-8A6C-B99582120781}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A75FA4DC-27AF-46EA-BB5B-8F1ABBF33645}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74549E6B-1B47-4AF7-8A6C-B99582120781}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/src/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Sinks.Slack</RootNamespace>
     <AssemblyName>Serilog.Sinks.Slack</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -35,6 +35,10 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\packages\Serilog.2.3.0\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.Sinks.PeriodicBatching.2.0.1\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
       <Private>True</Private>
@@ -43,9 +47,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="Serilog">
-      <HintPath>..\packages\Serilog.2.3.0\lib\net46\Serilog.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Serilog.Sinks.Slack/packages.config
+++ b/src/Serilog.Sinks.Slack/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net46" />
-  <package id="Serilog" version="2.3.0" targetFramework="net461" />
-  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.1" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Serilog" version="2.3.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
.NET 4.5 is the minimum supported version for Serilog
