### PR TITLE
Added support for message formatting and fixed a bug

### DIFF
--- a/Serilog.Sinks.Slack/Field.cs
+++ b/Serilog.Sinks.Slack/Field.cs
@@ -10,7 +10,7 @@ namespace Serilog.Sinks.Slack
         [JsonProperty("value")]
         public string Value { get; set; }
 
-        [JsonProperty("@short")]
+        [JsonProperty("short")]
         public bool? Short { get; set; }
     }
 }

--- a/Serilog.Sinks.Slack/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/SlackSinkOptions.cs
@@ -20,6 +20,21 @@ namespace Serilog.Sinks.Slack
         public bool ShowDefaultAttachments { get; set; } = true;
 
         /// <summary>
+        ///  Use the short format for attachments of all logs without exceptions. Default is true.
+        /// </summary>
+        public bool DefaultAttachmentsShortFormat { get; set; } = true;
+
+        /// <summary>
+        /// Show properties from the log context in the attachments. Default is true.
+        /// </summary>
+        public bool ShowPropertyAttachments { get; set; } = true;
+
+        /// <summary>
+        /// Use the short format for properties from the log context in the attachments. Default is true.
+        /// </summary>
+        public bool PropertyAttachmentsShortFormat { get; set; } = true;
+
+        /// <summary>
         /// Show attachments for exceptions, with the exception details. Default is true.
         /// </summary>
         public bool ShowExceptionAttachments { get; set; } = true;


### PR DESCRIPTION
Hi @mgibas,

I added support for the outputTemplate/message formatting. While doing so, I stumbled over a little bug that prevented the short format from being used for the attachments. I also added new options to allow the usage of the short format via config flag.

Furthermore, I added the possibility to have the log context properties being added as attachments as well. Really like it that way =)

Hope you find the time to merge this and publish the new version in a timely manner. Want to use this for some of our web services via the NuGet package :)

Cheers
Michael