### PR TITLE
Adding MinimumLogEventLevel to options. 

### DIFF
--- a/Serilog.Sinks.Slack/SlackSink.cs
+++ b/Serilog.Sinks.Slack/SlackSink.cs
@@ -46,6 +46,7 @@ namespace Serilog.Sinks.Slack
         {
             foreach (var logEvent in events)
             {
+                if (logEvent.Level < _options.MinimumLogEventLevel) continue;
                 var message = CreateMessage(logEvent);
                 var json = JsonConvert.SerializeObject(message, jsonSerializerSettings);
                 await Client.PostAsync(_options.WebHookUrl, new StringContent(json));

--- a/Serilog.Sinks.Slack/SlackSinkOptions.cs
+++ b/Serilog.Sinks.Slack/SlackSinkOptions.cs
@@ -76,5 +76,10 @@ namespace Serilog.Sinks.Slack
         /// Optional: A custom icon. Default is whatever is set on the integration page.
         /// </summary>
         public string CustomIcon { get; set; }
+
+        /// <summary>
+        /// Optional: A minimum log event level that will be sent to slack.
+        /// </summary>
+        public LogEventLevel MinimumLogEventLevel { get; set; }
     }
 }


### PR DESCRIPTION
 This allows the slack channel to receive more specific levels than the logger.