### PR TITLE
Add timestamp format parameter to configuration extension without formatter

### DIFF
--- a/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard1.1;netstandard1.3;netstandard2.0;net45;net46</TargetFrameworks>
     <Authors>mgibas,Sergey Kuznetsov,phnx47,TrapperHell</Authors>
     <Description>Serilog sink for Slack</Description>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <PackageProjectUrl>https://github.com/mgibas/serilog-sinks-slack</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Serilog.Sinks.Slack/SlackLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Slack/SlackLoggerConfigurationExtensions.cs
@@ -41,6 +41,7 @@ namespace Serilog.Sinks.Slack
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="propertyAllowList">If specified, only properties that match (case-insensitive) the name in the list are logged. Takes precedence over <see cref="SlackSinkOptions.PropertyDenyList"/></param>
         /// <param name="propertyDenyList">If specified, only properties that are not in this list are logged.</param>
+        /// <param name="timestampFormat">The <see href="https://docs.microsoft.com/dotnet/standard/base-types/standard-date-and-time-format-strings"> date and time format</see> for timestamps in messages.</param>
         /// <returns>Instance of <see cref="LoggerConfiguration"/> object.</returns>
         public static LoggerConfiguration Slack(
             this LoggerSinkConfiguration loggerSinkConfiguration,
@@ -59,7 +60,8 @@ namespace Serilog.Sinks.Slack
             string outputTemplate = DefaultOutputTemplate,
             IFormatProvider formatProvider = null,
             List<string> propertyAllowList = null,
-            List<string> propertyDenyList = null)
+            List<string> propertyDenyList = null,
+            string timestampFormat = null)
         {
 
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
@@ -78,7 +80,8 @@ namespace Serilog.Sinks.Slack
                 showExceptionAttachments,
                 restrictedToMinimumLevel,
                 propertyAllowList,
-                propertyDenyList);
+                propertyDenyList,
+                timestampFormat);
         }
 
         /// <summary>


### PR DESCRIPTION
@TrapperHell, sorry for the mess, but I forgot to add the new timestamp format parameter to the configuration extension method overload that doesn't take an `ITextFormatter`.